### PR TITLE
feat: build with postgres:10,11,12,13,14-alpine

### DIFF
--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -1,8 +1,0 @@
-FROM postgres:11-alpine
-
-RUN wget -qO- https://github.com/iCyberon/pg_hashids/archive/master.tar.gz | tar xzf - -C /tmp && \
-    apk add --no-cache --virtual .build-deps make gcc libc-dev postgresql-dev && \
-    make -C /tmp/pg_hashids-master && \
-    make -C /tmp/pg_hashids-master install && \
-    rm -rf /tmp/pg_hashids-master && \
-    apk del .build-deps

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+IMAGE ?= thphuong/postgres-hashids
+TAGS ?= 10-alpine 11-alpine 12-alpine 13-alpine 14-alpine
+
+.PHONY: alpine
+
+alpine: $(TAGS)
+
+$(TAGS):
+	docker build . \
+		-f alpine.Dockerfile \
+		--build-arg TAG=$@ \
+		--cache-from $(IMAGE):$@ \
+		--tag $(IMAGE):$@

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,6 @@
-FROM postgres:10-alpine
+ARG TAG
+
+FROM postgres:${TAG}
 
 RUN wget -qO- https://github.com/iCyberon/pg_hashids/archive/master.tar.gz | tar xzf - -C /tmp && \
     apk add --no-cache --virtual .build-deps make gcc libc-dev postgresql-dev && \


### PR DESCRIPTION
Update script to build images for PostgreSQL 12, 13, 14.

New images with the following tags:
```
thphuong/postgres-hashids:10-alpine
thphuong/postgres-hashids:11-alpine
thphuong/postgres-hashids:12-alpine
thphuong/postgres-hashids:13-alpine
thphuong/postgres-hashids:14-alpine
```